### PR TITLE
Make the algorithm track pathToVertex

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,20 @@ Map<Vertex<Integer>, VertexResult<Integer>> result = sps.solveStartingFrom(v1);
 ```
 ### Result
 
-|       Vertex       | Previous Vertex | Sum of weights to vertex |
-|:------------------:|:---------------:|:------------------------:|
-| intVertex1 (start) |       ---       |             0            |
-|     intVertex2     |    intVertex5   |        2147485677        |
-|     intVertex3     |    intVertex1   |           1000           |
-|     intVertex4     |    intVertex3   |           1200           |
-|     intVertex5     |    intVertex6   |        2147485647        |
-|     intVertex6     |    intVertex3   |           2000           |
+|       Vertex       | Previous Vertex | Sum of weights to vertex | pathToVertex                                   |
+|:------------------:|:---------------:|:------------------------:|:----------------------------------------------:|
+| intVertex1 (start) |       ---       |             0            | ---                                            |
+|     intVertex2     |    intVertex5   |        2147485677        | intVertex1, intVertex3, intVertex6, intVertex5 |
+|     intVertex3     |    intVertex1   |           1000           | intVertex1                                     |
+|     intVertex4     |    intVertex3   |           1200           | intVertex1, intVertex3                         |
+|     intVertex5     |    intVertex6   |        2147485647        | intVertex1, intVertex3, intVertex6             |
+|     intVertex6     |    intVertex3   |           2000           | intVertex1, intVertex3                         |
 
 
 Only vertexes that are reachable from the start vertex will be placed in the result map.
 For example, if our graph has a vertex without any outgoing edges, and we will call **solveStartingFrom()** method passing that 
 vertex as an argument, we will receive a map that has only one key (starting vertex). That key's value (**VertexResult<>**) will always have *sumOfWeights* equal to 0 and *previousVertex* set to *null*.
+
+**VertexResult<>** *pathToVertex* is a linked list that stores vertexes in order in which they were visited before 
+reaching the vertex that is a key of **VertexResult<>**. The table above shows, that the last element of *pathToVertex*
+is always equal to the element that is stored in *previousVertex* of **VertexResult<>**. 

--- a/src/main/java/ml/echelon133/graph/ShortestPathSolver.java
+++ b/src/main/java/ml/echelon133/graph/ShortestPathSolver.java
@@ -59,6 +59,7 @@ public class ShortestPathSolver<T extends Number & Comparable<T>> {
 
             v2Result.setSumOfWeights(potentialNewPathWeight);
             v2Result.setPreviousVertex(v1);
+            v2Result.copyAndUpdatePathToVertexFrom(v1Result);
 
             // update the priority of v2 after updating its sumOfWeights value
             // the simplest way to update priority in PriorityQueue is to remove an element and put it again

--- a/src/main/java/ml/echelon133/graph/VertexResult.java
+++ b/src/main/java/ml/echelon133/graph/VertexResult.java
@@ -1,17 +1,20 @@
 package ml.echelon133.graph;
 
 import java.math.BigDecimal;
+import java.util.LinkedList;
 
 public class VertexResult<T extends Number & Comparable<T>> {
     private Vertex<T> sourceVertex;
     private Vertex<T> previousVertex;
     private BigDecimal sumOfWeights;
+    private LinkedList<Vertex<T>> pathToVertex;
 
     public VertexResult(Vertex<T> sourceVertex) {
         this.sourceVertex = sourceVertex;
         this.previousVertex = null;
         // indicate infinite value with null, because it is impossible to get BigInteger or BigDecimal MAX_VALUE
         this.sumOfWeights = null;
+        this.pathToVertex = new LinkedList<>();
     }
 
     public Vertex<T> getSourceVertex() {
@@ -36,5 +39,17 @@ public class VertexResult<T extends Number & Comparable<T>> {
 
     public void setSumOfWeights(BigDecimal sumOfWeights) {
         this.sumOfWeights = sumOfWeights;
+    }
+
+    public LinkedList<Vertex<T>> getPathToVertex() {
+        return pathToVertex;
+    }
+
+    public void copyAndUpdatePathToVertexFrom(VertexResult<T> prevVertexResult) {
+        // Path to this (sourceVertex) vertex is a copy of a path to the previousVertex...
+        this.pathToVertex = new LinkedList<>(prevVertexResult.getPathToVertex());
+
+        // With the previous vertex itself added to it. Last element of pathToVertex should always be equal to previousVertex
+        this.pathToVertex.add(prevVertexResult.getSourceVertex());
     }
 }

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -275,26 +275,37 @@ public class ShortestPathSolverTest {
                 case "floatVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0").floatValue(), vertexSumOfWeights, 0.00001f);
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "floatVertex2":
                     assertEquals("floatVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("13.856").floatValue(), vertexSumOfWeights, 0.00001f);
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "floatVertex3":
                     assertEquals("floatVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("13.855").floatValue(), vertexSumOfWeights, 0.00001f);
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "floatVertex4":
                     assertEquals("floatVertex2", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("7820.389186").floatValue(), vertexSumOfWeights, 0.00001f);
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "floatVertex5":
                     assertEquals("floatVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("13.856").floatValue(), vertexSumOfWeights, 0.00001f);
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "floatVertex6":
                     assertEquals("floatVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("14.39179").floatValue(), vertexSumOfWeights, 0.00001f);
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     fail("Unexpected vertex in the tested graph");

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -101,22 +101,31 @@ public class ShortestPathSolverTest {
                 case "shortVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0"), testedVertexResult.getSumOfWeights());
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "shortVertex2":
                     assertEquals("shortVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("9"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "shortVertex3":
                     assertEquals("shortVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("5"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "shortVertex4":
                     assertEquals("shortVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("32772"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "shortVertex5":
                     assertEquals("shortVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("32767"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     fail("Unexpected vertex in the tested graph");

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -213,26 +213,37 @@ public class ShortestPathSolverTest {
                 case "longVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0"), testedVertexResult.getSumOfWeights());
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "longVertex2":
                     assertEquals("longVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("9223372036854775807"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "longVertex3":
                     assertEquals("longVertex2", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("18446744073709551614"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "longVertex4":
                     assertEquals("longVertex2", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("9223372036854776110"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "longVertex5":
                     assertEquals("longVertex4", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("9223372036854781110"), testedVertexResult.getSumOfWeights());
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "longVertex6":
                     assertEquals("longVertex4", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("9223372036854776410"), testedVertexResult.getSumOfWeights());
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     fail("Unexpected vertex in the tested graph");

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -390,26 +390,37 @@ public class ShortestPathSolverTest {
                 case "bigIntVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0"), testedVertexResult.getSumOfWeights());
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "bigIntVertex2":
                     assertEquals("bigIntVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("9223372036854775807"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigIntVertex3":
                     assertEquals("bigIntVertex2", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("18446744073709551614"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigIntVertex4":
                     assertEquals("bigIntVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("27670116110564327421"), testedVertexResult.getSumOfWeights());
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigIntVertex5":
                     assertEquals("bigIntVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("27670116110564327421"), testedVertexResult.getSumOfWeights());
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigIntVertex6":
                     assertEquals("bigIntVertex5", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("36893488147419103228"), testedVertexResult.getSumOfWeights());
+                    assertEquals(4, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     fail("Unexpected vertex in the tested graph");

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -449,30 +449,43 @@ public class ShortestPathSolverTest {
                 case "bigDecVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0"), testedVertexResult.getSumOfWeights());
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "bigDecVertex2":
                     assertEquals("bigDecVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("0.000001"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigDecVertex3":
                     assertEquals("bigDecVertex7", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("0.00000010001001"), testedVertexResult.getSumOfWeights());
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigDecVertex4":
                     assertEquals("bigDecVertex2", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("0.000001001"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigDecVertex5":
                     assertEquals("bigDecVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("0.0000001"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigDecVertex6":
                     assertEquals("bigDecVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("0.0000001000100100001"), testedVertexResult.getSumOfWeights());
+                    assertEquals(4, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "bigDecVertex7":
                     assertEquals("bigDecVertex5", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("0.00000010001"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     fail("Unexpected vertex in the tested graph");

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -47,22 +47,31 @@ public class ShortestPathSolverTest {
                 case "byteVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0"), testedVertexResult.getSumOfWeights());
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "byteVertex2":
                     assertEquals("byteVertex5", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("14"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "byteVertex3":
                     assertEquals("byteVertex5", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("11"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "byteVertex4":
                     assertEquals("byteVertex2", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("47"), testedVertexResult.getSumOfWeights());
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "byteVertex5":
                     assertEquals("byteVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("5"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     // this should never execute

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -337,22 +337,31 @@ public class ShortestPathSolverTest {
                 case "doubleVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0").doubleValue(), vertexSumOfWeights, 0.00001);
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "doubleVertex2":
                     assertEquals("doubleVertex4", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("1008.667").doubleValue(), vertexSumOfWeights, 0.00001);
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "doubleVertex3":
                     assertEquals("doubleVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("1.8776").doubleValue(), vertexSumOfWeights, 0.00001);
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "doubleVertex4":
                     assertEquals("doubleVertex5", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("1008.666").doubleValue(), vertexSumOfWeights, 0.00001);
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "doubleVertex5":
                     assertEquals("doubleVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("7.1").doubleValue(), vertexSumOfWeights, 0.00001);
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     fail("Unexpected vertex in the tested graph");

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -154,26 +154,37 @@ public class ShortestPathSolverTest {
                 case "intVertex1":
                     assertNull(testedVertexResult.getPreviousVertex());
                     assertEquals(new BigDecimal("0"), testedVertexResult.getSumOfWeights());
+                    assertEquals(0, testedVertexResult.getPathToVertex().size());
                     break;
                 case "intVertex2":
                     assertEquals("intVertex5", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("2147485677"), testedVertexResult.getSumOfWeights());
+                    assertEquals(4, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "intVertex3":
                     assertEquals("intVertex1", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("1000"), testedVertexResult.getSumOfWeights());
+                    assertEquals(1, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "intVertex4":
                     assertEquals("intVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("1200"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "intVertex5":
                     assertEquals("intVertex6", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("2147485647"), testedVertexResult.getSumOfWeights());
+                    assertEquals(3, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 case "intVertex6":
                     assertEquals("intVertex3", testedVertexResult.getPreviousVertex().getName());
                     assertEquals(new BigDecimal("2000"), testedVertexResult.getSumOfWeights());
+                    assertEquals(2, testedVertexResult.getPathToVertex().size());
+                    assertEquals(testedVertexResult.getPreviousVertex(), testedVertexResult.getPathToVertex().getLast());
                     break;
                 default:
                     fail("Unexpected vertex in the tested graph");

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -190,11 +190,11 @@ public class TestGraphStore {
     /*
         If we start from doubleVertex1, expected solution is:
 
-        doubleVertex1 | Prev vertex: ---           | sumOfWeights to doubleVertex1: 0
-        doubleVertex2 | Prev vertex: doubleVertex4 | sumOfWeights to doubleVertex2: 1008.667
-        doubleVertex3 | Prev vertex: doubleVertex1 | sumOfWeights to doubleVertex3: 1.8776
-        doubleVertex4 | Prev vertex: doubleVertex5 | sumOfWeights to doubleVertex4: 1008.666
-        doubleVertex5 | Prev vertex: doubleVertex1 | sumOfWeights to doubleVertex5: 7.1
+        doubleVertex1 | Prev vertex: ---           | sumOfWeights to doubleVertex1: 0        | pathToVertex: []
+        doubleVertex2 | Prev vertex: doubleVertex4 | sumOfWeights to doubleVertex2: 1008.667 | pathToVertex: [doubleVertex1, doubleVertex5, doubleVertex4]
+        doubleVertex3 | Prev vertex: doubleVertex1 | sumOfWeights to doubleVertex3: 1.8776   | pathToVertex: [doubleVertex1]
+        doubleVertex4 | Prev vertex: doubleVertex5 | sumOfWeights to doubleVertex4: 1008.666 | pathToVertex: [doubleVertex1, doubleVertex5]
+        doubleVertex5 | Prev vertex: doubleVertex1 | sumOfWeights to doubleVertex5: 7.1      | pathToVertex: [doubleVertex1]
 
          */
     public static Graph<Double> getDoubleTestGraph() {

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -9,11 +9,11 @@ public class TestGraphStore {
     /*
     If we start from byteVertex1, expected solution is:
 
-    byteVertex1 | Prev vertex: ---         | sumOfWeights to byteVertex1: 0
-    byteVertex2 | Prev vertex: byteVertex5 | sumOfWeights to byteVertex2: 14
-    byteVertex3 | Prev vertex: byteVertex5 | sumOfWeights to byteVertex3: 11
-    byteVertex4 | Prev vertex: byteVertex2 | sumOfWeights to byteVertex4: 47
-    byteVertex5 | Prev vertex: byteVertex1 | sumOfWeights to byteVertex5: 5
+    byteVertex1 | Prev vertex: ---         | sumOfWeights to byteVertex1: 0  | pathToVertex: []
+    byteVertex2 | Prev vertex: byteVertex5 | sumOfWeights to byteVertex2: 14 | pathToVertex: [byteVertex1, byteVertex5]
+    byteVertex3 | Prev vertex: byteVertex5 | sumOfWeights to byteVertex3: 11 | pathToVertex: [byteVertex1, byteVertex5]
+    byteVertex4 | Prev vertex: byteVertex2 | sumOfWeights to byteVertex4: 47 | pathToVertex: [byteVertex1, byteVertex5, byteVertex2]
+    byteVertex5 | Prev vertex: byteVertex1 | sumOfWeights to byteVertex5: 5  | pathToVertex: [byteVertex1]
 
      */
     public static Graph<Byte> getByteTestGraph() {

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -116,12 +116,12 @@ public class TestGraphStore {
     /*
         If we start from longVertex1, expected solution is:
 
-        longVertex1 | Prev vertex: ---         | sumOfWeights to longVertex1: 0
-        longVertex2 | Prev vertex: longVertex1 | sumOfWeights to longVertex2: 9223372036854775807
-        longVertex3 | Prev vertex: longVertex2 | sumOfWeights to longVertex3: 18446744073709551614
-        longVertex4 | Prev vertex: longVertex2 | sumOfWeights to longVertex4: 9223372036854776110
-        longVertex5 | Prev vertex: longVertex4 | sumOfWeights to longVertex5: 9223372036854781110
-        longVertex6 | Prev vertex: longVertex4 | sumOfWeights to longVertex6: 9223372036854776410
+        longVertex1 | Prev vertex: ---         | sumOfWeights to longVertex1: 0                    | pathToVertex: []
+        longVertex2 | Prev vertex: longVertex1 | sumOfWeights to longVertex2: 9223372036854775807  | pathToVertex: [longVertex1]
+        longVertex3 | Prev vertex: longVertex2 | sumOfWeights to longVertex3: 18446744073709551614 | pathToVertex: [longVertex1, longVertex2]
+        longVertex4 | Prev vertex: longVertex2 | sumOfWeights to longVertex4: 9223372036854776110  | pathToVertex: [longVertex1, longVertex2]
+        longVertex5 | Prev vertex: longVertex4 | sumOfWeights to longVertex5: 9223372036854781110  | pathToVertex: [longVertex1, longVertex2, longVertex4]
+        longVertex6 | Prev vertex: longVertex4 | sumOfWeights to longVertex6: 9223372036854776410  | pathToVertex: [longVertex1, longVertex2, longVertex4]
 
          */
     public static Graph<Long> getLongTestGraph() {

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -153,12 +153,12 @@ public class TestGraphStore {
     /*
         If we start from floatVertex1, expected solution is:
 
-        floatVertex1 | Prev vertex: ---          | sumOfWeights to floatVertex1: 0
-        floatVertex2 | Prev vertex: floatVertex1 | sumOfWeights to floatVertex2: 13.856
-        floatVertex3 | Prev vertex: floatVertex1 | sumOfWeights to floatVertex3: 13.855
-        floatVertex4 | Prev vertex: floatVertex2 | sumOfWeights to floatVertex4: 7820.389186
-        floatVertex5 | Prev vertex: floatVertex3 | sumOfWeights to floatVertex5: 13.856
-        floatVertex6 | Prev vertex: floatVertex3 | sumOfWeights to floatVertex6: 14.39179
+        floatVertex1 | Prev vertex: ---          | sumOfWeights to floatVertex1: 0           | pathToVertex: []
+        floatVertex2 | Prev vertex: floatVertex1 | sumOfWeights to floatVertex2: 13.856      | pathToVertex: [floatVertex1]
+        floatVertex3 | Prev vertex: floatVertex1 | sumOfWeights to floatVertex3: 13.855      | pathToVertex: [floatVertex1]
+        floatVertex4 | Prev vertex: floatVertex2 | sumOfWeights to floatVertex4: 7820.389186 | pathToVertex: [floatVertex1, floatVertex2]
+        floatVertex5 | Prev vertex: floatVertex3 | sumOfWeights to floatVertex5: 13.856      | pathToVertex: [floatVertex1, floatVertex3]
+        floatVertex6 | Prev vertex: floatVertex3 | sumOfWeights to floatVertex6: 14.39179    | pathToVertex: [floatVertex1, floatVertex3]
 
          */
     public static Graph<Float> getFloatTestGraph() {

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -45,11 +45,11 @@ public class TestGraphStore {
     /*
     If we start from shortVertex1, expected solution is:
 
-    shortVertex1 | Prev vertex: ---          | sumOfWeights to shortVertex1: 0
-    shortVertex2 | Prev vertex: shortVertex5 | sumOfWeights to shortVertex2: 9
-    shortVertex3 | Prev vertex: shortVertex5 | sumOfWeights to shortVertex3: 5
-    shortVertex4 | Prev vertex: shortVertex2 | sumOfWeights to shortVertex4: 32772
-    shortVertex5 | Prev vertex: shortVertex1 | sumOfWeights to shortVertex5: 32767
+    shortVertex1 | Prev vertex: ---          | sumOfWeights to shortVertex1: 0      | pathToVertex: []
+    shortVertex2 | Prev vertex: shortVertex3 | sumOfWeights to shortVertex2: 9      | pathToVertex: [shortVertex1, shortVertex3]
+    shortVertex3 | Prev vertex: shortVertex1 | sumOfWeights to shortVertex3: 5      | pathToVertex: [shortVertex1]
+    shortVertex4 | Prev vertex: shortVertex3 | sumOfWeights to shortVertex4: 32772  | pathToVertex: [shortVertex1, shortVertex3]
+    shortVertex5 | Prev vertex: shortVertex1 | sumOfWeights to shortVertex5: 32767  | pathToVertex: [shortVertex1]
 
      */
     public static Graph<Short> getShortTestGraph() {

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -226,12 +226,12 @@ public class TestGraphStore {
     /*
         If we start from bigIntVertex1, expected solution is:
 
-        bigIntVertex1 | Prev vertex: ---           | sumOfWeights to bigIntVertex1: 0
-        bigIntVertex2 | Prev vertex: bigIntVertex1 | sumOfWeights to bigIntVertex2: 9223372036854775807
-        bigIntVertex3 | Prev vertex: bigIntVertex2 | sumOfWeights to bigIntVertex3: 18446744073709551614
-        bigIntVertex4 | Prev vertex: bigIntVertex3 | sumOfWeights to bigIntVertex4: 27670116110564327421
-        bigIntVertex5 | Prev vertex: bigIntVertex3 | sumOfWeights to bigIntVertex5: 27670116110564327421
-        bigIntVertex6 | Prev vertex: bigIntVertex5 | sumOfWeights to bigIntVertex6: 36893488147419103228
+        bigIntVertex1 | Prev vertex: ---           | sumOfWeights to bigIntVertex1: 0                    | pathToVertex: []
+        bigIntVertex2 | Prev vertex: bigIntVertex1 | sumOfWeights to bigIntVertex2: 9223372036854775807  | pathToVertex: [bigIntVertex1]
+        bigIntVertex3 | Prev vertex: bigIntVertex2 | sumOfWeights to bigIntVertex3: 18446744073709551614 | pathToVertex: [bigIntVertex1, bigIntVertex2]
+        bigIntVertex4 | Prev vertex: bigIntVertex3 | sumOfWeights to bigIntVertex4: 27670116110564327421 | pathToVertex: [bigIntVertex1, bigIntVertex2, bigIntVertex3]
+        bigIntVertex5 | Prev vertex: bigIntVertex3 | sumOfWeights to bigIntVertex5: 27670116110564327421 | pathToVertex: [bigIntVertex1, bigIntVertex2, bigIntVertex3]
+        bigIntVertex6 | Prev vertex: bigIntVertex5 | sumOfWeights to bigIntVertex6: 36893488147419103228 | pathToVertex: [bigIntVertex1, bigIntVertex2, bigIntVertex3, bigIntVertex5]
 
          */
     public static Graph<BigInteger> getBigIntegerTestGraph() {

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -79,12 +79,12 @@ public class TestGraphStore {
     /*
         If we start from intVertex1, expected solution is:
 
-        intVertex1 | Prev vertex: ---        | sumOfWeights to intVertex1: 0
-        intVertex2 | Prev vertex: intVertex5 | sumOfWeights to intVertex2: 2147485677
-        intVertex3 | Prev vertex: intVertex1 | sumOfWeights to intVertex3: 1000
-        intVertex4 | Prev vertex: intVertex3 | sumOfWeights to intVertex4: 1200
-        intVertex5 | Prev vertex: intVertex6 | sumOfWeights to intVertex5: 2147485647
-        intVertex6 | Prev vertex: intVertex3 | sumOfWeights to intVertex6: 2000
+        intVertex1 | Prev vertex: ---        | sumOfWeights to intVertex1: 0          | pathToVertex: []
+        intVertex2 | Prev vertex: intVertex5 | sumOfWeights to intVertex2: 2147485677 | pathToVertex: [intVertex1, intVertex3, intVertex6, intVertex5]
+        intVertex3 | Prev vertex: intVertex1 | sumOfWeights to intVertex3: 1000       | pathToVertex: [intVertex1]
+        intVertex4 | Prev vertex: intVertex3 | sumOfWeights to intVertex4: 1200       | pathToVertex: [intVertex1, intVertex3]
+        intVertex5 | Prev vertex: intVertex6 | sumOfWeights to intVertex5: 2147485647 | pathToVertex: [intVertex1, intVertex3, intVertex6]
+        intVertex6 | Prev vertex: intVertex3 | sumOfWeights to intVertex6: 2000       | pathToVertex: [intVertex1, intVertex3]
 
          */
     public static Graph<Integer> getIntegerTestGraph() {

--- a/src/test/java/ml/echelon133/graph/TestGraphStore.java
+++ b/src/test/java/ml/echelon133/graph/TestGraphStore.java
@@ -260,13 +260,13 @@ public class TestGraphStore {
     /*
         If we start from bigDecVertex1, expected solution is:
 
-        bigDecVertex1 | Prev vertex: ---           | sumOfWeights to bigDecVertex1: 0
-        bigDecVertex2 | Prev vertex: bigDecVertex1 | sumOfWeights to bigDecVertex2: 0.000001
-        bigDecVertex3 | Prev vertex: bigDecVertex7 | sumOfWeights to bigDecVertex3: 0.00000010001001
-        bigDecVertex4 | Prev vertex: bigDecVertex2 | sumOfWeights to bigDecVertex4: 0.000001001
-        bigDecVertex5 | Prev vertex: bigDecVertex1 | sumOfWeights to bigDecVertex5: 0.0000001
-        bigDecVertex6 | Prev vertex: bigDecVertex3 | sumOfWeights to bigDecVertex6: 0.0000001000100100001
-        bigDecVertex7 | Prev vertex: bigDecVertex5 | sumOfWeights to bigDecVertex7: 0.00000010001
+        bigDecVertex1 | Prev vertex: ---           | sumOfWeights to bigDecVertex1: 0                     | pathToVertex: []
+        bigDecVertex2 | Prev vertex: bigDecVertex1 | sumOfWeights to bigDecVertex2: 0.000001              | pathToVertex: [bigDecVertex1]
+        bigDecVertex3 | Prev vertex: bigDecVertex7 | sumOfWeights to bigDecVertex3: 0.00000010001001      | pathToVertex: [bigDecVertex1, bigDecVertex5, bigDecVertex7]
+        bigDecVertex4 | Prev vertex: bigDecVertex2 | sumOfWeights to bigDecVertex4: 0.000001001           | pathToVertex: [bigDecVertex1, bigDecVertex2]
+        bigDecVertex5 | Prev vertex: bigDecVertex1 | sumOfWeights to bigDecVertex5: 0.0000001             | pathToVertex: [bigDecVertex1]
+        bigDecVertex6 | Prev vertex: bigDecVertex3 | sumOfWeights to bigDecVertex6: 0.0000001000100100001 | pathToVertex: [bigDecVertex1, bigDecVertex5, bigDecVertex7, bigDecVertex3]
+        bigDecVertex7 | Prev vertex: bigDecVertex5 | sumOfWeights to bigDecVertex7: 0.00000010001         | pathToVertex: [bigDecVertex1, bigDecVertex5]
 
          */
     public static Graph<BigDecimal> getBigDecimalTestGraph() {


### PR DESCRIPTION
Now after every execution of **solveStartingFrom** method, the result map's value (**VertexResult<>**) will contain a linked list of all vertexes that the algorithm had visited before reaching the vertex that is the key of that particular **VertexResult<>**,