### PR TITLE
Find vertex by name

### DIFF
--- a/src/main/java/ml/echelon133/graph/Graph.java
+++ b/src/main/java/ml/echelon133/graph/Graph.java
@@ -11,4 +11,5 @@ public interface Graph<T extends Number & Comparable<T>> {
     void addEdge(Edge<T> e) throws IllegalArgumentException;
     void addEdge(Vertex<T> source, Vertex<T> destination, T weight) throws IllegalArgumentException;
     void removeEdge(Edge<T> e);
+    Vertex<T> findVertex(String vName);
 }

--- a/src/main/java/ml/echelon133/graph/WeightedGraph.java
+++ b/src/main/java/ml/echelon133/graph/WeightedGraph.java
@@ -77,4 +77,9 @@ public class WeightedGraph<T extends Number & Comparable<T>> implements Graph<T>
         Vertex<T> source = e.getSource();
         source.removeEdge(e);
     }
+
+    @Override
+    public Vertex<T> findVertex(String vName) {
+        return vertexHelperMap.get(vName);
+    }
 }

--- a/src/test/java/ml/echelon133/graph/ResultMapSerializerTest.java
+++ b/src/test/java/ml/echelon133/graph/ResultMapSerializerTest.java
@@ -42,8 +42,7 @@ public class ResultMapSerializerTest {
     public void serializeByteGraphResultMap() throws Exception {
         Graph<Byte> byteGraph = TestGraphStore.getByteTestGraph();
 
-        Vertex<Byte> startVertex = byteGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("byteVertex1")).findFirst().get();
+        Vertex<Byte> startVertex = byteGraph.findVertex("byteVertex1");
 
         ShortestPathSolver<Byte> sps = new ShortestPathSolver<>(byteGraph);
         Map<Vertex<Byte>, VertexResult<Byte>> resultMap = sps.solveStartingFrom(startVertex);
@@ -89,8 +88,7 @@ public class ResultMapSerializerTest {
     public void serializeShortGraphResultMap() throws Exception {
         Graph<Short> shortGraph = TestGraphStore.getShortTestGraph();
 
-        Vertex<Short> startVertex = shortGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("shortVertex1")).findFirst().get();
+        Vertex<Short> startVertex = shortGraph.findVertex("shortVertex1");
 
         ShortestPathSolver<Short> sps = new ShortestPathSolver<>(shortGraph);
         Map<Vertex<Short>, VertexResult<Short>> resultMap = sps.solveStartingFrom(startVertex);
@@ -136,8 +134,7 @@ public class ResultMapSerializerTest {
     public void serializeIntegerGraphResultMap() throws Exception {
         Graph<Integer> intGraph = TestGraphStore.getIntegerTestGraph();
 
-        Vertex<Integer> startVertex = intGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("intVertex1")).findFirst().get();
+        Vertex<Integer> startVertex = intGraph.findVertex("intVertex1");
 
         ShortestPathSolver<Integer> sps = new ShortestPathSolver<>(intGraph);
         Map<Vertex<Integer>, VertexResult<Integer>> resultMap = sps.solveStartingFrom(startVertex);
@@ -183,8 +180,7 @@ public class ResultMapSerializerTest {
     public void serializeLongGraphResultMap() throws Exception {
         Graph<Long> longGraph = TestGraphStore.getLongTestGraph();
 
-        Vertex<Long> startVertex = longGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("longVertex1")).findFirst().get();
+        Vertex<Long> startVertex = longGraph.findVertex("longVertex1");
 
         ShortestPathSolver<Long> sps = new ShortestPathSolver<>(longGraph);
         Map<Vertex<Long>, VertexResult<Long>> resultMap = sps.solveStartingFrom(startVertex);
@@ -230,8 +226,7 @@ public class ResultMapSerializerTest {
     public void serializeFloatGraphResultMap() throws Exception {
         Graph<Float> floatGraph = TestGraphStore.getFloatTestGraph();
 
-        Vertex<Float> startVertex = floatGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("floatVertex1")).findFirst().get();
+        Vertex<Float> startVertex = floatGraph.findVertex("floatVertex1");
 
         ShortestPathSolver<Float> sps = new ShortestPathSolver<>(floatGraph);
         Map<Vertex<Float>, VertexResult<Float>> resultMap = sps.solveStartingFrom(startVertex);
@@ -277,8 +272,7 @@ public class ResultMapSerializerTest {
     public void serializeDoubleGraphResultMap() throws Exception {
         Graph<Double> doubleGraph = TestGraphStore.getDoubleTestGraph();
 
-        Vertex<Double> startVertex = doubleGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("doubleVertex1")).findFirst().get();
+        Vertex<Double> startVertex = doubleGraph.findVertex("doubleVertex1");
 
         ShortestPathSolver<Double> sps = new ShortestPathSolver<>(doubleGraph);
         Map<Vertex<Double>, VertexResult<Double>> resultMap = sps.solveStartingFrom(startVertex);
@@ -324,8 +318,7 @@ public class ResultMapSerializerTest {
     public void serializeBigIntegerGraphResultMap() throws Exception {
         Graph<BigInteger> bigIntGraph = TestGraphStore.getBigIntegerTestGraph();
 
-        Vertex<BigInteger> startVertex = bigIntGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("bigIntVertex1")).findFirst().get();
+        Vertex<BigInteger> startVertex = bigIntGraph.findVertex("bigIntVertex1");
 
         ShortestPathSolver<BigInteger> sps = new ShortestPathSolver<>(bigIntGraph);
         Map<Vertex<BigInteger>, VertexResult<BigInteger>> resultMap = sps.solveStartingFrom(startVertex);
@@ -371,8 +364,7 @@ public class ResultMapSerializerTest {
     public void serializeBigDecimalGraphResultMap() throws Exception {
         Graph<BigDecimal> bigDecGraph = TestGraphStore.getBigDecimalTestGraph();
 
-        Vertex<BigDecimal> startVertex = bigDecGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("bigDecVertex1")).findFirst().get();
+        Vertex<BigDecimal> startVertex = bigDecGraph.findVertex("bigDecVertex1");
 
         ShortestPathSolver<BigDecimal> sps = new ShortestPathSolver<>(bigDecGraph);
         Map<Vertex<BigDecimal>, VertexResult<BigDecimal>> resultMap = sps.solveStartingFrom(startVertex);

--- a/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
+++ b/src/test/java/ml/echelon133/graph/ShortestPathSolverTest.java
@@ -32,8 +32,7 @@ public class ShortestPathSolverTest {
         Graph<Byte> byteGraph = TestGraphStore.getByteTestGraph();
         ShortestPathSolver<Byte> sps = new ShortestPathSolver<>(byteGraph);
 
-        Vertex<Byte> startVertex = byteGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("byteVertex1")).findFirst().get();
+        Vertex<Byte> startVertex = byteGraph.findVertex("byteVertex1");
 
         Map<Vertex<Byte>, VertexResult<Byte>> resultMap = sps.solveStartingFrom(startVertex);
 
@@ -86,8 +85,7 @@ public class ShortestPathSolverTest {
         Graph<Short> shortGraph = TestGraphStore.getShortTestGraph();
         ShortestPathSolver<Short> sps = new ShortestPathSolver<>(shortGraph);
 
-        Vertex<Short> startVertex = shortGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("shortVertex1")).findFirst().get();
+        Vertex<Short> startVertex = shortGraph.findVertex("shortVertex1");
 
         Map<Vertex<Short>, VertexResult<Short>> resultMap = sps.solveStartingFrom(startVertex);
 
@@ -139,8 +137,7 @@ public class ShortestPathSolverTest {
         Graph<Integer> intGraph = TestGraphStore.getIntegerTestGraph();
         ShortestPathSolver<Integer> sps = new ShortestPathSolver<>(intGraph);
 
-        Vertex<Integer> startVertex = intGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("intVertex1")).findFirst().get();
+        Vertex<Integer> startVertex = intGraph.findVertex("intVertex1");
 
         Map<Vertex<Integer>, VertexResult<Integer>> resultMap = sps.solveStartingFrom(startVertex);
 
@@ -198,8 +195,7 @@ public class ShortestPathSolverTest {
         Graph<Long> longGraph = TestGraphStore.getLongTestGraph();
         ShortestPathSolver<Long> sps = new ShortestPathSolver<>(longGraph);
 
-        Vertex<Long> startVertex = longGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("longVertex1")).findFirst().get();
+        Vertex<Long> startVertex = longGraph.findVertex("longVertex1");
 
         Map<Vertex<Long>, VertexResult<Long>> resultMap = sps.solveStartingFrom(startVertex);
 
@@ -257,8 +253,7 @@ public class ShortestPathSolverTest {
         Graph<Float> floatGraph = TestGraphStore.getFloatTestGraph();
         ShortestPathSolver<Float> sps = new ShortestPathSolver<>(floatGraph);
 
-        Vertex<Float> startVertex = floatGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("floatVertex1")).findFirst().get();
+        Vertex<Float> startVertex = floatGraph.findVertex("floatVertex1");
 
         Map<Vertex<Float>, VertexResult<Float>> resultMap = sps.solveStartingFrom(startVertex);
 
@@ -319,8 +314,7 @@ public class ShortestPathSolverTest {
         Graph<Double> doubleGraph = TestGraphStore.getDoubleTestGraph();
         ShortestPathSolver<Double> sps = new ShortestPathSolver<>(doubleGraph);
 
-        Vertex<Double> startVertex = doubleGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("doubleVertex1")).findFirst().get();
+        Vertex<Double> startVertex = doubleGraph.findVertex("doubleVertex1");
 
         Map<Vertex<Double>, VertexResult<Double>> resultMap = sps.solveStartingFrom(startVertex);
 
@@ -375,8 +369,7 @@ public class ShortestPathSolverTest {
         Graph<BigInteger> bigIntGraph = TestGraphStore.getBigIntegerTestGraph();
         ShortestPathSolver<BigInteger> sps = new ShortestPathSolver<>(bigIntGraph);
 
-        Vertex<BigInteger> startVertex = bigIntGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("bigIntVertex1")).findFirst().get();
+        Vertex<BigInteger> startVertex = bigIntGraph.findVertex("bigIntVertex1");
 
         Map<Vertex<BigInteger>, VertexResult<BigInteger>> resultMap = sps.solveStartingFrom(startVertex);
 
@@ -434,8 +427,7 @@ public class ShortestPathSolverTest {
         Graph<BigDecimal> bigDecGraph = TestGraphStore.getBigDecimalTestGraph();
         ShortestPathSolver<BigDecimal> sps = new ShortestPathSolver<>(bigDecGraph);
 
-        Vertex<BigDecimal> startVertex = bigDecGraph
-                .getVertexes().stream().filter(v -> v.getName().equals("bigDecVertex1")).findFirst().get();
+        Vertex<BigDecimal> startVertex = bigDecGraph.findVertex("bigDecVertex1");
 
         Map<Vertex<BigDecimal>, VertexResult<BigDecimal>> resultMap = sps.solveStartingFrom(startVertex);
 

--- a/src/test/java/ml/echelon133/graph/WeightedGraphTest.java
+++ b/src/test/java/ml/echelon133/graph/WeightedGraphTest.java
@@ -189,4 +189,20 @@ public class WeightedGraphTest {
         assertFalse(graph.getEdges().contains(e4));
         assertFalse(graph.getEdges().contains(e6));
     }
+
+    @Test
+    public void findVertexWorks() {
+        Graph<Integer> graph = new WeightedGraph<>();
+
+        Vertex<Integer> v1 = new Vertex<>("v1");
+        Vertex<Integer> v2 = new Vertex<>("v2");
+
+        graph.addVertex(v1);
+
+        Vertex<Integer> foundV1 = graph.findVertex("v1");
+        Vertex<Integer> foundV2 = graph.findVertex("v2");
+
+        assertEquals(v1, foundV1);
+        assertNull(foundV2);
+    }
 }

--- a/src/test/java/ml/echelon133/graph/WeightedGraphTest.java
+++ b/src/test/java/ml/echelon133/graph/WeightedGraphTest.java
@@ -205,4 +205,30 @@ public class WeightedGraphTest {
         assertEquals(v1, foundV1);
         assertNull(foundV2);
     }
+
+    @Test
+    public void findVertexReturnsNullOnRemovedVertexes() {
+        Graph<Integer> graph = new WeightedGraph<>();
+
+        Vertex<Integer> v1 = new Vertex<>("v1");
+        Vertex<Integer> v2 = new Vertex<>("v2");
+
+        graph.addVertex(v1);
+        graph.addVertex(v2);
+
+        Vertex<Integer> foundV1 = graph.findVertex("v1");
+        Vertex<Integer> foundV2 = graph.findVertex("v2");
+
+        assertEquals(v1, foundV1);
+        assertEquals(v2, foundV2);
+
+        graph.removeVertex(v1);
+        graph.removeVertex(v2);
+
+        foundV1 = graph.findVertex("v1");
+        foundV2 = graph.findVertex("v2");
+
+        assertNull(foundV1);
+        assertNull(foundV2);
+    }
 }


### PR DESCRIPTION
Now instead of filtering the stream of vertexes we can use the findVertex method that makes use of WeightedGraph internal vertex map. This is a lot faster.